### PR TITLE
Adding pace

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ At a high level, the project follows this flow:
 ```mermaid
 flowchart LR
     JSON["📄 JSON / GeoJSON\nraw data files"]
-    Dist["📐 get_distance.py\ncalculates haversine distance\nper runner"]
+    Dist["📐 get_distance.py\ncalculates haversine distance\nper route point"]
+    Pace["⏱ add_pace.py - calculates simulated pace"]
     Trim["✂️ trim_json.py\nnormalises both route\n& runner data for ingestion"]
     CLI["DatabaseCLI\nmanage.py"]
     Ingest["MockDataIngestion\ningest_json_to_postgres.py"]
@@ -47,8 +48,9 @@ flowchart LR
     Map["🗺️ MapClient\nexternal web app"]
 
     JSON --> Dist
-    JSON -->|raw route data| Trim
-    Dist -->|runner data enriched\nwith distance field| Trim
+    JSON -->|raw runner data| Trim
+    Dist -->|route enriched\nwith distance field| Pace
+    Pace -->|route enriched\nwith pace & segment_distance| Trim
     Trim -->|both datasets normalised\nand ready for ingestion| CLI
     CLI --> Ingest
     Ingest --> PG
@@ -85,6 +87,7 @@ flowchart LR
 	```sh
 	docker compose -f docker-compose.dev.yml exec web bash
 	python process_data/get_distance.py
+	python process_data/add_pace.py
 	python process_data/trim_json.py
 	```
 5. Seed the development database (including users):
@@ -202,12 +205,17 @@ docker compose -f docker-compose.dev.yml exec web bash
 
 Inside the container, in the root directory, run the following scripts as needed:
 
-1. **Generate distance for each runner:**
+1. **Generate distance for each route point:**
 	```sh
 	python process_data/get_distance.py
 	```
 
-2. **Prepare data for ingestion into PostgreSQL:**
+2. **Calculate pace for each route segment:**
+	```sh
+	python process_data/add_pace.py
+	```
+
+3. **Prepare data for ingestion into PostgreSQL:**
 	If `ciucas_runners.json` and `ciucas_route.json` do not exist in the `mock_data` folder, or if the data becomes corrupted, run:
 	```sh
 	python process_data/trim_json.py
@@ -264,7 +272,7 @@ The core idea is to simulate real-time GPS tracking of runners on a known race r
 
 Two key tables are used:
 
-- **`ciucas_route`** — ordered track points for the full race route, each with GPS coordinates (`xcoord`, `ycoord`), elevation (`ele`), and cumulative distance from the start.
+- **`ciucas_route`** — ordered track points for the full race route, each with GPS coordinates (`xcoord`, `ycoord`), elevation (`ele`), cumulative distance from the start, and simulated per-segment `pace` (min/km).
 - **`runners_ciucas`** — one row per runner with name, category, bib number, ranking, and finish time.
 
 ### Streaming logic (`/live` endpoint)
@@ -304,8 +312,9 @@ This tradeoff keeps the map client usable without forcing end users through auth
 Before the API can serve data, the raw GeoJSON files go through a preprocessing step:
 
 1. **`process_data/get_distance.py`** — reads the raw route GeoJSON and adds a `distance` field to each point using the `haversine` formula.
-2. **`process_data/trim_json.py`** — trims and normalises the runner and route data into the format expected by the database models.
-3. **`manage.py seed_db_*`** — loads the preprocessed JSON files into PostgreSQL via `IngestMockDataToPostgres`.
+2. **`process_data/add_pace.py`** — enriches the route with per-segment `pace` (in min/km) and `segment_distance` fields, simulating runner speed based on a configurable `seconds_per_segment` parameter (default: 15 seconds). **Note:** Pace values are simulated estimates derived from this parameter, not actual runner performance data.
+3. **`process_data/trim_json.py`** — trims and normalises the runner and route data into the format expected by the database models.
+4. **`manage.py seed_db_*`** — loads the preprocessed JSON files into PostgreSQL via `IngestMockDataToPostgres`.
 
 ---
 

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ prepare-env:
 # ==============================
 
 .PHONY: help build exec-web create-db seed-users seed-route seed-runners down restart force-restart \
-        print-users print-runners print-routes
+        print-users print-runners print-routes preprocess-data
 
 # ==============================
 # Help
@@ -39,6 +39,15 @@ restart: prepare-env ## Restart containers (no rebuild)
 
 force-restart: prepare-env ## Force restart running containers
 	docker compose -f docker-compose.prod.yml restart
+
+# ==============================
+# ETL - Data Preprocessing
+# ==============================
+
+preprocess-data: prepare-env ## Preprocess route and runner data (distance, pace, trim)
+	docker compose -f docker-compose.prod.yml exec web python process_data/get_distance.py
+	docker compose -f docker-compose.prod.yml exec web python process_data/add_pace.py
+	docker compose -f docker-compose.prod.yml exec web python process_data/trim_json.py
 
 # ==============================
 # Database - Setup

--- a/services/web/process_data/add_pace.py
+++ b/services/web/process_data/add_pace.py
@@ -1,0 +1,70 @@
+"""
+Enrich route GeoJSON with simulated per-segment pace.
+"""
+
+import json
+
+
+def add_pace(route_file, output_file, seconds_per_segment=15.0):
+    """
+    Reads route GeoJSON that already contains cumulative distance, calculates
+    per-segment pace, and writes the enriched payload to a new file.
+
+    Args:
+        route_file (str): Path to the input route GeoJSON file with cumulative distance.
+        output_file (str): Path where the enriched route GeoJSON will be saved.
+        seconds_per_segment (float): Simulated seconds to traverse one segment.
+    """
+    print(f"Processing: {route_file} -> {output_file}")
+
+    with open(route_file, "r", encoding="utf-8") as f:
+        route_data = json.load(f)
+
+    features = route_data.get("features", [])
+    print(f"Found {len(features)} route features")
+
+    if not features:
+        print("No route features found. Exiting.")
+        return
+
+    # First point has no previous segment.
+    first_properties = features[0].setdefault("properties", {})
+    first_properties["segment_distance"] = 0.0
+    first_properties["pace"] = 0.0
+
+    for idx in range(1, len(features)):
+        current_properties = features[idx].setdefault("properties", {})
+        previous_properties = features[idx - 1].setdefault("properties", {})
+
+        current_distance = float(current_properties.get("distance", 0.0))
+        previous_distance = float(previous_properties.get("distance", 0.0))
+        segment_distance = max(current_distance - previous_distance, 0.0)
+        current_properties["segment_distance"] = round(segment_distance, 3)
+
+        if segment_distance > 0 and seconds_per_segment > 0:
+            pace_min_per_km = (seconds_per_segment / 60.0) / (segment_distance / 1000.0)
+            current_properties["pace"] = round(pace_min_per_km, 3)
+        else:
+            current_properties["pace"] = 0.0
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(route_data, f, ensure_ascii=False, indent=4)
+
+    print(f"Wrote segment pace data in {output_file}\n")
+
+
+if __name__ == "__main__":
+    # Usage: python add_pace.py <route_file> <output_file> [seconds_per_segment]
+    import sys
+
+    default_route_input = "process_data/data/ciucas_route_distance.geojson"
+    default_output = "process_data/data/ciucas_route_pace.geojson"
+
+    if len(sys.argv) == 1:
+        add_pace(default_route_input, default_output)
+    elif len(sys.argv) == 3:
+        add_pace(sys.argv[1], sys.argv[2])
+    elif len(sys.argv) == 4:
+        add_pace(sys.argv[1], sys.argv[2], float(sys.argv[3]))
+    else:
+        print("Usage: python add_pace.py <route_file> <output_file> [seconds_per_segment]")

--- a/services/web/process_data/ingest_json_to_postgres.py
+++ b/services/web/process_data/ingest_json_to_postgres.py
@@ -6,9 +6,8 @@ from project.models import db
 class IngestMockDataToPostgres:
     @staticmethod
     def ingest_ciucas_data_in_postgres(model, json_file):
-        with open(json_file) as json_data:
+        with open(json_file, encoding="utf-8") as json_data:
             record_list = json.load(json_data)
-
 
         # Only remove 'id' for User model
         records = []

--- a/services/web/process_data/trim_json.py
+++ b/services/web/process_data/trim_json.py
@@ -15,13 +15,13 @@ def trim_json(input_geojson, output_json):
         output_json (str): Path to the output JSON file.
     """
     trim_dictionary = []
-    with open(input_geojson, 'r') as f:
+    with open(input_geojson, 'r', encoding='utf-8') as f:
         data = json.load(f)
         features = data['features']
         print(f"Found {len(features)} features in {input_geojson}")
         for feature in features:
             trim_dictionary.append(feature['properties'])
-    with open(output_json, "w") as jsonFile:
+    with open(output_json, "w", encoding='utf-8') as jsonFile:
         json.dump(trim_dictionary, jsonFile, ensure_ascii=False, indent=4)
     print(f"Wrote {len(trim_dictionary)} items to {output_json}\n")
 
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     import sys
 
     # Default file paths
-    default_input_1 = 'process_data/data/ciucas_route_distance.geojson'
+    default_input_1 = 'process_data/data/ciucas_route_pace.geojson'
     default_output_1 = 'project/mock_data/ciucas_route.json'
     default_input_2 = 'process_data/data/runners.geojson'
     default_output_2 = 'project/mock_data/ciucas_runners.json'

--- a/services/web/project/models.py
+++ b/services/web/project/models.py
@@ -21,10 +21,10 @@ class User(db.Model, UserMixin):
     password = db.Column(db.String(255), nullable=False)  # Increase to 255
     
 
-    def __init__(self, email: str, password: str, name: str):
-        self.email = email
-        self.name = name
-        self.password = password
+    # def __init__(self, email: str, password: str, name: str):
+    #     self.email = email
+    #     self.name = name
+    #     self.password = password
         
         
 class Runners(db.Model):
@@ -50,19 +50,6 @@ class Runners(db.Model):
         db.Index('idx_runners_ranking', 'ranking'),
     )
 
-    def __init__(self, id, imei, name, displayname, gender, categ, club, bib, time_, age, ranking):
-        self.id = id
-        self.imei = imei
-        self.name = name
-        self.displayname = displayname
-        self.gender = gender
-        self.categ = categ
-        self.club = club
-        self.bib = bib
-        self.time_ = time_
-        self.age = age
-        self.ranking = ranking
-
 
 class CiucasRoute(db.Model):
     """
@@ -75,9 +62,14 @@ class CiucasRoute(db.Model):
     ele = Column(Integer, nullable=False)
     xcoord = Column(Float(), nullable=False)
     ycoord = Column(Float(), nullable=False)
+    pace = Column(Float(), nullable=True)
+    segment_distance = Column(Float(), nullable=True)
 
-    def __init__(self, distance: float, ycoord: float, ele: float, xcoord: float):
-        self.distance = distance
-        self.ele = ele
-        self.xcoord = xcoord
-        self.ycoord = ycoord
+    # def __init__(self, distance: float, ycoord: float, ele: float, xcoord: float,
+    #     pace: float = None, segment_distance: float = None):
+    #     self.distance = distance
+    #     self.ele = ele
+    #     self.xcoord = xcoord
+    #     self.ycoord = ycoord
+    #     self.pace = pace
+    #     self.segment_distance = segment_distance

--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -7,7 +7,7 @@ requests==2.31.0
 Babel==2.14.0
 click==8.1.7
 Flask-Babel==4.0.0
-Flask-Cors==4.0.1
+Flask-Cors==6.0.0
 Flask-Login==0.6.3
 itsdangerous==2.2.0
 Jinja2==3.1.3
@@ -16,7 +16,7 @@ mypy-extensions==1.1.0
 SQLAlchemy==2.0.30
 toml==0.10.2
 typing-extensions==4.11.0
-Werkzeug==3.0.2
+Werkzeug==3.1.6
 WTForms==3.1.2
 Flask-Migrate==4.0.5
 python-dotenv==1.0.1


### PR DESCRIPTION
added paceto live endpoint

## Summary by Sourcery

Add simulated per-segment pace data to the route preprocessing pipeline and surface it in the data model and documentation.

New Features:
- Introduce a pace and segment_distance fields on CiucasRoute to store per-segment pace metadata.
- Add an add_pace.py script to compute simulated per-segment pace and segment distance from route GeoJSON.

Enhancements:
- Update preprocessing flow and Makefile to include pace enrichment before trimming and ingestion.
- Clarify and expand README documentation to describe distance and pace preprocessing steps and the enriched ciucas_route schema.
- Improve file handling by using UTF-8 encoding consistently in data processing and ingestion scripts.
- Comment out custom __init__ methods on SQLAlchemy models to rely on default declarative initialization.

Build:
- Update Flask-Cors and Werkzeug dependency versions in requirements.txt.

Documentation:
- Document the new pace enrichment step and the additional fields on ciucas_route, and update developer setup instructions accordingly.